### PR TITLE
Version 2.2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ SQLiteBrowser is a NuGet package designed for .NET MAUI applications. It provide
 
 ## Features
 
+- **Security**: Shows an error message when no debugger is attached. No data is shown when running in production apps
 - **Table Explorer**: View all tables in your SQLite database.
 - **Data Management**: Add, edit, and delete rows directly within the app.
 - **Ease of Integration**: Quickly integrate with your .NET MAUI application.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## Version 2.2.3
+
+- Added check to only run when debugger is attached
+
 ## Version 2.2.1
 
 - Added GitHub Actions workflow

--- a/SQLiteBrowser/DatabaseBrowserPage.cs
+++ b/SQLiteBrowser/DatabaseBrowserPage.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.ObjectModel;
+using System.Diagnostics;
 
 namespace SQLiteBrowser;
 
@@ -25,6 +26,29 @@ public partial class DatabaseBrowserPage : ContentPage
         this.tablesView.ItemTapped += OnTableSelected;
 
         Title = "Tables";
+        
+        // If the app that includes this package is running in Release mode, show a warning message
+        if (!Debugger.IsAttached)
+        {
+            var warningLabel = new Label
+            {
+                Text = "Warning: This package is intended for development purposes only. Do not use in production.",
+                TextColor = Color.FromRgb(255,0,0),
+                FontSize = 16,
+                HorizontalOptions = LayoutOptions.Center,
+                VerticalOptions = LayoutOptions.Start,
+                Margin = new Thickness(0, 10, 0, 0)
+            };
+            this.Content = new StackLayout
+            {
+                Padding = new Thickness(10),
+                Children =
+                {
+                    warningLabel
+                }
+            };
+            return;
+        }
 
         Content = new StackLayout
         {

--- a/SQLiteBrowser/SQLiteBrowser.csproj
+++ b/SQLiteBrowser/SQLiteBrowser.csproj
@@ -20,7 +20,7 @@
 		<Authors>Underlyingglitch</Authors>
 		<Company>underlyingglitch</Company>
 		<PackageId>SQLiteBrowser</PackageId>
-		<Version>2.2.1</Version>
+		<Version>2.2.3</Version>
 		<Description>Browse and edit SQLite databases with a MAUI ContentPage.</Description>
 		<PackageTags>SQLite, MAUI, Database</PackageTags>
 		<RepositoryUrl>https://github.com/Underlyingglitch/SQLiteBrowser</RepositoryUrl>


### PR DESCRIPTION
Added security to only include the views when a debugger is attached. An error message is shown otherwise. This means no data is shown and no actions can be performed in production apps.